### PR TITLE
feat: trust all proxies in middleware configuration

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->trustProxies('*');
         $middleware->web(append: [
             \App\Http\Middleware\HandleInertiaRequests::class,
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,


### PR DESCRIPTION
This pull request includes a small change to the `bootstrap/app.php` file. The change adds a middleware configuration to trust all proxies.

* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R14): Added `$middleware->trustProxies('*');` to trust all proxies.