### PR TITLE
fix: exclude 'Guest' role from teams retrieval for users

### DIFF
--- a/app/Services/TeamService.php
+++ b/app/Services/TeamService.php
@@ -12,6 +12,7 @@ class TeamService
       ->join("teams_mapping", "teams.id", "=", "teams_mapping.teams_id")
       ->join("teams_roles", "teams_mapping.role_id", "=", "teams_roles.id")
       ->where("teams_mapping.member_id", $userId)
+      ->where("teams_roles.name", "!=", "Guest")
       ->select("teams.*", "teams_roles.name as role_name")
       ->get();
   }


### PR DESCRIPTION
This pull request includes a change to the `TeamService` class to improve the filtering of teams for a user. The change ensures that users with the role "Guest" are excluded from the result set.

* [`app/Services/TeamService.php`](diffhunk://#diff-871bcd55dc28e7c13829fe1ce1aa071b92a3cdb208a92868dc833c38038165ceR15): Added a condition to exclude users with the role "Guest" in the `getTeamsForUser` method.