### PR TITLE
fix: remove unnecessary --force flag from php artisan optimize comman…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN php artisan config:clear \
   && php artisan config:cache \
   && php artisan route:clear \
   && php artisan route:cache \
-  && php artisan optimize --force
+  && php artisan optimize
 
 # Set permissions
 RUN chown -R www-data:www-data /var/www/html


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change removes the `--force` flag from the `php artisan optimize` command.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L46-R46): Removed the `--force` flag from the `php artisan optimize` command.…d in Dockerfile