### PR TITLE
fix: remove unnecessary --force flag from php artisan optimize comman…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.3-apache
 
+# Install dependencies
 RUN apt-get update && apt-get install -y \
   libzip-dev \
   zip \
@@ -9,30 +10,44 @@ RUN a2enmod rewrite
 
 RUN docker-php-ext-install pdo_mysql zip
 
-# get node js version 20
+# Get Node.js version 20
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
   && apt-get install -y nodejs
 
+# Set Apache document root
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
+# Copy application files
 COPY . /var/www/html
 
 RUN ls -la /var/www/html
 
+# Set working directory
 WORKDIR /var/www/html
 
+# Install Node.js dependencies and build
 RUN npm install
-
 RUN npm run build
 
+# Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
+# Install PHP dependencies
 RUN composer install
 
+# Run Laravel Artisan commands
+RUN php artisan config:clear \
+  && php artisan config:cache \
+  && php artisan route:clear \
+  && php artisan route:cache \
+  && php artisan optimize --force
+
+# Set permissions
 RUN chown -R www-data:www-data /var/www/html
 RUN chmod -R 755 /var/www/html
 
+# Start services
 CMD ["sh", "-c", "npm run preview & apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN php artisan config:clear \
   && php artisan config:cache \
   && php artisan route:clear \
   && php artisan route:cache \
-  && php artisan optimize --force
+  && php artisan optimize
 
 # Set permissions
 RUN chown -R www-data:www-data /var/www/html


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change involves modifying the `RUN php artisan config:clear` command to remove the `--force` flag from the `php artisan optimize` command.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L46-R46): Removed the `--force` flag from the `php artisan optimize` command.