### PR TITLE
fix: adjust AvatarFallback size and reposition AddTeamButton in TeamList

### DIFF
--- a/resources/js/pages/Dashboard/User/Partials/TeamCard.tsx
+++ b/resources/js/pages/Dashboard/User/Partials/TeamCard.tsx
@@ -24,7 +24,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team }) => {
                             className="h-14 w-14 rounded-lg"
                             src={team.icon ?? ""}
                         />
-                        <AvatarFallback className="h-14 w-14 rounded-lg text-4xl">
+                        <AvatarFallback className="h-10 w-10 rounded-lg text-4xl">
                             {team.name.charAt(0).toUpperCase()}
                         </AvatarFallback>
                     </Avatar>

--- a/resources/js/pages/Dashboard/User/Partials/TeamList.tsx
+++ b/resources/js/pages/Dashboard/User/Partials/TeamList.tsx
@@ -8,10 +8,10 @@ interface TeamListProps {
 const TeamList: React.FC<TeamListProps> = ({ teams }) => {
     return (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            <AddTeamButton />
             {teams.map((team) => (
                 <TeamCard key={team.id} team={team} />
             ))}
+            <AddTeamButton />
         </div>
     );
 };


### PR DESCRIPTION
This pull request includes changes to the user interface components in the `Dashboard` page, specifically focusing on the `TeamCard` and `TeamList` components. The changes primarily involve adjustments to the layout and appearance of the team cards and the positioning of the "Add Team" button.

Changes to `TeamCard` component:

* [`resources/js/pages/Dashboard/User/Partials/TeamCard.tsx`](diffhunk://#diff-b828daf0721e2b28fd74d94d7de3ed85bc5c8a4357afa77813344e0c2cedd6c1L27-R27): Adjusted the size of the `AvatarFallback` element from `h-14 w-14` to `h-10 w-10` to make the fallback avatar smaller.

Changes to `TeamList` component:

* [`resources/js/pages/Dashboard/User/Partials/TeamList.tsx`](diffhunk://#diff-d800a9b717b672e0698e611b5d3be279c4c00edc759864c02793cb85a9671b9fL11-R14): Moved the `AddTeamButton` to be rendered after the list of teams instead of before, improving the layout.